### PR TITLE
ABA004 — Create Known Record type rules

### DIFF
--- a/ABAValidatorAPI/Services/Rules/RecordRules.cs
+++ b/ABAValidatorAPI/Services/Rules/RecordRules.cs
@@ -7,15 +7,15 @@ namespace ABAValidatorAPI.Services.Rules
         [GeneratedRegex(@"^.{120}$")]
         private static partial Regex Line120();
 
-        public KeyValuePair<Regex, string> DiscrptiveChar1 
+        public KeyValuePair<Regex, string> DiscrptiveChar1
         {
-            get => new (DescriptiveChar1(), "Char 1, Size 1, Record type 0, Must be '0'"); 
+            get => new(DescriptiveChar1(), "Char 1, Size 1, Record type 0, Must be '0'");
         }
 
         public Dictionary<Regex, string> DescriptiveRules { get; } = new()
         {
             {Line120()               , "An ABA record is exactly 120 characters long (excluding new line characters)" },
-            
+
             {DescriptiveChar1()      , "Char 1, Size 1, Record type 0, Must be '0'" },
             {DescriptiveChar2_18()   , "Char 2-18, Size 17, Blank, Must be filled" },
             {DescriptiveChar19_20()  , "Char 19-20, Size 2, Reel Sequence Number, Must be numeric commencing at 01. Right justified. Zero filled." },
@@ -111,10 +111,25 @@ Where account number exceeds nine characters, edit out hyphens. Right justified,
                         return TotalRules;
                     }
                 default:
-                    { 
-                        throw new ArgumentOutOfRangeException(); 
+                    {
+                        return KnownRecordRules;
                     }
             }
         }
+
+        public Dictionary<Regex, string> KnownRecordRules { get; } = new()
+        {
+            {Line120()     , @"An ABA record is exactly 120 characters long (excluding new line characters)" },
+
+            {KnownChar1()  , @"Char 1, Size 1, Record type, Must be '0' or '1' or '7'" },
+            //todo: complete all rules
+            //todo: split compex rules
+        };
+
+
+        [GeneratedRegex(@"^[017].*$")]
+        private static partial Regex KnownChar1();
+
     }
+
 }

--- a/ABAValidatorAPI/wwwroot/testdata/invalid.aba
+++ b/ABAValidatorAPI/wwwroot/testdata/invalid.aba
@@ -1,4 +1,5 @@
 0                 01TEST BANK      PAYROLL          000000000 123456 01                                                 
 1TEST BANK BSB   123-456789012345  000000000Salary Payment      0000010000N                                             
-1SUPPLIER BSB    987-654321098765  000000000Invoice Payment     0000020000N                                             
+1SUPPLIER BSB    987-654321098765  000000000Invoice Payment     0000020000N           
+2SUPPLIER BS    987-654321098765  000000000Invoice Payment     0000020000N           
 7999-999            0000000000000000020000000000010000                                                                  


### PR DESCRIPTION
1. Create rules
   - record has to be of known type (0, 1 or 7)
3. Add a record of wrong type
   - into invalid.aba file